### PR TITLE
Download item collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `Client.download_item_collection()` ([#20](https://github.com/gadomski/stac-asset/pull/20))
+
+### Changed
+
+- Behavior of the item file name in `Client.download_item()` ([#20](https://github.com/gadomski/stac-asset/pull/20))
+
 ## [0.0.3] - 2023-05-31
 
 ### Added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from pystac import Item
+from pystac import Item, ItemCollection
 from pytest import Config, Parser
 
 
@@ -16,6 +16,11 @@ def asset_href() -> str:
 @pytest.fixture
 def item() -> Item:
     return Item.from_file(str(Path(__file__).parent / "data" / "item.json"))
+
+
+@pytest.fixture
+def item_collection(item: Item) -> ItemCollection:
+    return ItemCollection([item])
 
 
 def pytest_addoption(parser: Parser) -> None:

--- a/tests/test_filesystem_client.py
+++ b/tests/test_filesystem_client.py
@@ -2,7 +2,7 @@ import os.path
 from pathlib import Path
 
 import pytest
-from pystac import Asset, Item
+from pystac import Asset, Item, ItemCollection
 from stac_asset import (
     AssetDownloadWarning,
     AssetOverwriteException,
@@ -21,16 +21,27 @@ def href() -> str:
 async def test_download(tmp_path: Path, href: str) -> None:
     async with FilesystemClient() as client:
         await client.download_href(href, tmp_path / "out.jpg")
-        assert os.path.getsize(tmp_path / "out.jpg") == 31367
+
+    assert os.path.getsize(tmp_path / "out.jpg") == 31367
 
 
-async def test_item_download(tmp_path: Path, item: Item) -> None:
+async def test_download_item(tmp_path: Path, item: Item) -> None:
     async with FilesystemClient() as client:
         item = await client.download_item(item, tmp_path)
-        assert Path(tmp_path / f"{item.id}.json").exists()
 
-        asset = item.assets["data"]
-        assert asset.href == "./20201211_223832_CS2.jpg"
+    assert Path(tmp_path / "item.json").exists()
+    asset = item.assets["data"]
+    assert asset.href == "./20201211_223832_CS2.jpg"
+
+
+async def test_download_item_collection(
+    tmp_path: Path, item_collection: ItemCollection
+) -> None:
+    async with FilesystemClient() as client:
+        await client.download_item_collection(item_collection, tmp_path)
+
+    assert os.path.exists(tmp_path / "item-collection.json")
+    assert os.path.exists(tmp_path / "test-item" / "20201211_223832_CS2.jpg")
 
 
 async def test_item_download_404(tmp_path: Path, item: Item) -> None:
@@ -38,6 +49,7 @@ async def test_item_download_404(tmp_path: Path, item: Item) -> None:
     async with FilesystemClient() as client:
         with pytest.warns(AssetDownloadWarning):
             await client.download_item(item, tmp_path)
+
     assert not (tmp_path / "not-a-file").exists()
 
 
@@ -54,7 +66,8 @@ async def test_item_download_key(tmp_path: Path, item: Item) -> None:
         await client.download_item(
             item, tmp_path, asset_file_name_strategy=FileNameStrategy.KEY
         )
-        assert Path(tmp_path / "data.jpg").exists()
+
+    assert Path(tmp_path / "data.jpg").exists()
 
 
 async def test_item_download_same_file_name(tmp_path: Path, item: Item) -> None:


### PR DESCRIPTION
## Related issues and pull requests

- Closes #6 

## Description

Also includes a change to the `item_file_name` behavior -- now, we default to `item.json`, and if it's `None` don't write the file.

## Checklist

- [x] Add tests
- [x] Add docs
- [x] Update CHANGELOG
